### PR TITLE
feat: upgrade sdk js version, fix example

### DIFF
--- a/sdk-web-js/README.md
+++ b/sdk-web-js/README.md
@@ -49,3 +49,10 @@ npm run dev
 ```
 
 Open [http://localhost:5000](http://localhost:5000) and your are done!
+
+
+## Files overview
+
+* `src/video-recorder.js` A vanilla [web component](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) that displays video, canvas elements and a button to start the capture. It create a recording session and setup lifecycle methods
+* `src/main.js` handle capture result and displays it on the page. It handle preset change
+* `public/index.html` html page, it contains [template](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots) for `video-recorder` component

--- a/sdk-web-js/package-lock.json
+++ b/sdk-web-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@unissey/sdk-web-js": "^0.2.0-alpha.2"
+        "@unissey/sdk-web-js": "^0.3.2"
       },
       "devDependencies": {
         "webpack": "^5.75.0",
@@ -260,9 +260,9 @@
       }
     },
     "node_modules/@unissey/sdk-web-js": {
-      "version": "0.2.0-alpha.2",
-      "resolved": "https://npm.pkg.github.com/download/@unissey/sdk-web-js/0.2.0-alpha.2/f4163d18d038c990aaeb0f82ec651ec958c8217d",
-      "integrity": "sha512-51tLhhkNQw9ZXb4/0uwKCUBiL1cVaYYrKFeKxXFygoVNqkCiUStZLSkBAVhHIOkYEc+Ga0cKBpLTEd3zSPzd4w==",
+      "version": "0.3.2",
+      "resolved": "https://npm.pkg.github.com/download/@unissey/sdk-web-js/0.3.2/8eb0c4fe6afe39352ad188dfb3b34b8ca5b0d5d0",
+      "integrity": "sha512-jI8yCAW1phGAEOgTmmyzDJKDWqXAFvThL+wD2xVUrhZdM+E2kWZ+qdeH75TZrEIXIo5FSMYhji5ATRe+IXnAcQ==",
       "license": "Unissey license agreement",
       "dependencies": {
         "events": "^3.2.0",
@@ -3655,9 +3655,9 @@
       }
     },
     "@unissey/sdk-web-js": {
-      "version": "0.2.0-alpha.2",
-      "resolved": "https://npm.pkg.github.com/download/@unissey/sdk-web-js/0.2.0-alpha.2/f4163d18d038c990aaeb0f82ec651ec958c8217d",
-      "integrity": "sha512-51tLhhkNQw9ZXb4/0uwKCUBiL1cVaYYrKFeKxXFygoVNqkCiUStZLSkBAVhHIOkYEc+Ga0cKBpLTEd3zSPzd4w==",
+      "version": "0.3.2",
+      "resolved": "https://npm.pkg.github.com/download/@unissey/sdk-web-js/0.3.2/8eb0c4fe6afe39352ad188dfb3b34b8ca5b0d5d0",
+      "integrity": "sha512-jI8yCAW1phGAEOgTmmyzDJKDWqXAFvThL+wD2xVUrhZdM+E2kWZ+qdeH75TZrEIXIo5FSMYhji5ATRe+IXnAcQ==",
       "requires": {
         "events": "^3.2.0",
         "webm-wasm": "^0.4.1"

--- a/sdk-web-js/package.json
+++ b/sdk-web-js/package.json
@@ -24,6 +24,6 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "@unissey/sdk-web-js": "^0.2.0-alpha.2"
+    "@unissey/sdk-web-js": "^0.3.2"
   }
 }

--- a/sdk-web-js/public/index.html
+++ b/sdk-web-js/public/index.html
@@ -7,31 +7,41 @@
   </head>
   <body>
     <main class="main item-center">
+      <div class="preset-selector">
+        <h2>Select a preset</h2>
+        <form>
+          <select id="preset-select" class="preset-select">
+            <option value="selfie-substantial">SELFIE SUBSTANTIAL</option>
+            <option value="selfie-fast">SELFIE FAST</option> 
+            <option value="doc-video">DOC VIDEO</option>
+            <option value="doc-image">DOC IMAGE</option>
+          </select>
+        </form>
+      </div>
+
       <div class="container">
-        <div class="capture-zone">
+        <video-recorder id="video-recorder" preset="selfie-fast"></video-recorder> 
+        <div class="output-zone item-center" id="output-zone">
+          <span class="output-label" id="output-label">Capture output</span>
+        </div>
+      </div>
+    </main>
+
+    <template id="video-recorder-template">
+      <div class="capture-zone">
           <div class="recorder-container">
-            <div class="recorder-wrapper">
+            <div id="recorder-wrapper" class="recorder-wrapper">
               <canvas id="canvas" class="canvas"></canvas>
-              <video
-                id="video"
-                class="video"
-                autoplay
-                muted
+              <video id="video" class="video" autoplay muted
                 playsinline
               ></video>
             </div>
           </div>
 
           <div class="buttons item-center">
-            <button id="capture-btn" class="btn">Capture</button>
-            <button id="reset-btn" class="hidden">Reset</button>
+            <button id="capture-btn" class="btn" disabled>Capture</button>
           </div>
-        </div>
-
-        <div class="output-zone item-center" id="output-zone">
-          <span class="output-label" id="output-label">Capture output</span>
-        </div>
       </div>
-    </main>
+    </template>
   </body>
 </html>

--- a/sdk-web-js/public/styles.css
+++ b/sdk-web-js/public/styles.css
@@ -1,3 +1,7 @@
+:root {
+    font-family: sans-serif;
+}
+
 .main {
     width: 100%;
     height: 100vh;
@@ -30,14 +34,16 @@
     justify-content: space-between;
     align-items: center;
     width: 100%;
+    min-height: 225px;
+    max-height: 400px;
 }
 
 .recorder-wrapper {
     position: relative;
     top: 0;
     left: 0;
-    width: 400px;
-    height: 268px;
+    width: 100%;
+    max-height: 400px;
 }
 
 .video,
@@ -45,8 +51,8 @@
     position: absolute;
     top: 0;
     left: 0;
-    width: 400px;
-    height: 400px;
+    max-width: 400px;
+    max-height: 400px;
     border-radius: 10px;
 }
 
@@ -63,6 +69,7 @@
 
 .item-center {
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
 }
@@ -82,10 +89,16 @@
     border-radius: 10px;
     background-color: #333333;
     color: #ffffff;
-    cursor: pointer;
     font-size: 16px;
-
+    cursor: pointer;
     width: 100px;
+    z-index: 5;
+}
+
+.btn:disabled {
+    background-color: #ccc;
+    border-color: #ccc;
+    cursor: auto;
 }
 
 .hidden {
@@ -105,4 +118,17 @@
 .output-video {
     width: 400px;
     height: 268px;
+}
+
+.preset-selector {
+    margin: 25px;
+    text-align: center;
+}
+
+.preset-select {
+    border: solid 1px #333;
+    width: 200px;
+    height: 35px;
+    padding: 0 2px;
+    border-radius: 10px;
 }

--- a/sdk-web-js/src/main.js
+++ b/sdk-web-js/src/main.js
@@ -1,0 +1,66 @@
+import { AcquisitionPreset } from "@unissey/sdk-web-js";
+import "./video-recorder";
+
+const VALID_PRESETS = [
+    AcquisitionPreset.SELFIE_FAST, 
+    AcquisitionPreset.DOC_VIDEO, 
+    AcquisitionPreset.DOC_IMAGE, 
+    AcquisitionPreset.SELFIE_SUBSTANTIAL
+];
+
+function main() {
+    const videoRecorder = document.getElementById("video-recorder");
+
+    const outputZone = document.getElementById("output-zone");
+
+    videoRecorder.addEventListener("capture-done", (e) => {
+        const { media, metadata, preset } = e.detail;
+
+        // Media and metadata are used by Unissey API
+
+        // In the example an element displays the media
+
+        let outputElmt = null;
+
+        switch(preset) {
+            case AcquisitionPreset.SELFIE_FAST:
+                outputElmt = document.createElement("div");
+                outputElmt.innerHTML = `Mjpeg Player not implemented. This preset is not suited for human review`
+                break;
+            case AcquisitionPreset.DOC_IMAGE:
+                outputElmt = createMediaOutputElmt(media, "img");
+                break;
+            default:
+                outputElmt = createMediaOutputElmt(media, "video");
+        }
+
+        outputZone.replaceChildren(outputElmt);
+    })
+
+    const presetSelect = document.getElementById("preset-select");
+
+    presetSelect.addEventListener("change", (e) => {
+        const newPreset = e.target.value;
+
+        if(VALID_PRESETS.includes(newPreset)) {
+            videoRecorder.setAttribute("preset", newPreset)
+        }
+    });
+}
+
+/**
+ * @param {String} kind "img" | "video"
+ * @param {Blob} media
+ */
+function createMediaOutputElmt(media, kind) {
+    const outputElmt = document.createElement(kind);
+    outputElmt.setAttribute("src", URL.createObjectURL(media));
+    outputElmt.setAttribute("class", "output-video");
+    outputElmt.setAttribute("controls", "");
+    outputElmt.setAttribute("playsinline", "");
+  
+    return outputElmt;
+  }
+
+
+main();

--- a/sdk-web-js/src/utils.js
+++ b/sdk-web-js/src/utils.js
@@ -1,0 +1,9 @@
+/**
+* Set dimensions of html element
+* @param {HTMLElement} elmt 
+* @param {number} width 
+* @param {number} height 
+*/
+export function setElementDimensions(elmt, width, height) {
+    elmt.setAttribute("style", `width: ${width}px; height: ${height}px`)
+}

--- a/sdk-web-js/src/video-recorder.js
+++ b/sdk-web-js/src/video-recorder.js
@@ -75,8 +75,11 @@ class VideoRecorder extends HTMLElement {
       this.enableCaptureBtn()
     }
 
-    // Setup session parameters
-    this.config = {
+    this.createSession();
+  }
+
+  async createSession() {
+    this.recordSession = await UnisseySdk.createSession(this.videoElmt, this.preset, this.canvasElmt, {
       overlayConfig: {
         colors: {
           background: [33, 33, 33, 0.4], // background color of overlay
@@ -84,13 +87,7 @@ class VideoRecorder extends HTMLElement {
           progressColor: [255, 255, 255, 1], // displayed during acquisition
         },
       },
-    };
-
-    this.createSession();
-  }
-
-  async createSession() {
-    this.recordSession = await UnisseySdk.createSession(this.videoElmt, this.preset, this.canvasElmt, this.config);
+    });
   }
 
   async resetSession() {

--- a/sdk-web-js/src/video-recorder.js
+++ b/sdk-web-js/src/video-recorder.js
@@ -15,7 +15,7 @@ class VideoRecorder extends HTMLElement {
   constructor() {
     super();
 
-    // Values are difined when the element is mounted on the document
+    // Values are defined when the element is mounted on the document
    
     // HTML Elements
     this.canvasElmt = null;

--- a/sdk-web-js/webpack.config.js
+++ b/sdk-web-js/webpack.config.js
@@ -4,7 +4,7 @@ const outDir = path.resolve(__dirname, "public");
 
 module.exports = {
   entry: {
-    recorder: "./src/video-recorder.js",
+    recorder: "./src/main.js",
   },
   output: {
     filename: "[name].bundle.js",


### PR DESCRIPTION
Changes:

* Upgrade to sdk-web-js latest stable version 0.3.2

* Refactor the sdk js example to use a vanilla web component

* Add option to select the preset on the page

* Adjust the size of elements to fit aspect ratio of video

* Display output for each preset